### PR TITLE
feat: scrape and visualize metrics from grafana alloy

### DIFF
--- a/components/telemetry/config/prometheus/prometheus.yml
+++ b/components/telemetry/config/prometheus/prometheus.yml
@@ -24,6 +24,11 @@ scrape_configs:
           - kobol.fritz.box:9110
         labels:
           group: "docker-metrics"
+      - targets:
+          - caprica.fritz.box:12345
+          - kobol.fritz.box:12345
+        labels:
+          group: "alloy-metrics"
 
   - job_name: 'raspi-metrics'
     scrape_interval: 30s
@@ -39,6 +44,11 @@ scrape_configs:
           - testrunner-01-pi.fritz.box:9110
         labels:
           group: "docker-metrics"
+      - targets:
+          - admin-pi.fritz.box:12345
+          - testrunner-01-pi.fritz.box:12345
+        labels:
+          group: "alloy-metrics"
 
   - job_name: 'websites'
     metrics_path: /probe


### PR DESCRIPTION
Prometheus has been configured to scrape metrics from all Alloy instances across the homelab network.
Grafana now exposes dashboards to visualize and monitor these metrics.